### PR TITLE
feat: parse out metadata according to Web view Url

### DIFF
--- a/bili_jeans/core/constants.py
+++ b/bili_jeans/core/constants.py
@@ -1,0 +1,28 @@
+"""
+Constants
+"""
+
+
+###############################
+# Bilibili request parameters #
+###############################
+HEADERS = {
+    'origin': 'https://www.bilibili.com',
+    'referer': 'https://www.bilibili.com/',
+    'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+                  'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+    'accept': 'application/json, text/plain, */*',
+    'Sec-Ch-Ua': '"Chromium";v="124", "Google Chrome";v="124", "Not-A.Brand";v="99"',
+    'Sec-Ch-Ua-Mobile': '?0',
+    'Sec-Ch-Ua-Platform': '"macOS"',
+    'Sec-Fetch-Dest': 'empty',
+    'Sec-Fetch-Mode': 'cors',
+    'Sec-Fetch-Site': 'same-site'
+}
+TIMEOUT = 5
+
+
+################
+# Bilibili API #
+################
+URL_WEB_UGC_VIEW = 'https://api.bilibili.com/x/web-interface/view'

--- a/bili_jeans/core/factory.py
+++ b/bili_jeans/core/factory.py
@@ -1,0 +1,43 @@
+"""
+Factory on instance according to resource type
+"""
+import re
+from typing import Optional
+from urllib.parse import urlparse
+
+from pydantic import BaseModel
+
+
+BVID_LENGTH = 9
+WEB_VIEW_URL_UGC_BVID_PATTERN = re.compile(fr'/video/(BV1[a-zA-Z0-9]{{{BVID_LENGTH}}})')
+WEB_VIEW_URL_UGC_AVID_PATTERN = re.compile(r'/video/av(\d+)')
+
+
+WEB_VIEW_URL_ID_TYPE_MAPPING = {
+    WEB_VIEW_URL_UGC_BVID_PATTERN: ('bvid', str),
+    WEB_VIEW_URL_UGC_AVID_PATTERN: ('aid', int)
+}
+
+
+class WebViewMetaData(BaseModel):
+
+    aid: Optional[int] = None
+    bvid: Optional[str] = None
+
+
+def parse_web_view_url(url: str) -> WebViewMetaData:
+    """
+    extract metadata from web view URL
+    """
+    url_path = urlparse(url).path
+    for path_pattern in (WEB_VIEW_URL_UGC_BVID_PATTERN, WEB_VIEW_URL_UGC_AVID_PATTERN):
+        search_result = path_pattern.search(url_path)
+        if search_result:
+            metadata = WebViewMetaData()
+            field_name, func_name = WEB_VIEW_URL_ID_TYPE_MAPPING[path_pattern]
+            metadata.__setattr__(
+                field_name,
+                func_name(search_result.group(1))
+            )
+            return metadata
+    raise ValueError(f'Invalid Url: {url}')

--- a/bili_jeans/core/proxy.py
+++ b/bili_jeans/core/proxy.py
@@ -6,26 +6,8 @@ from typing import Dict, Optional
 
 import aiohttp
 
+from .constants import HEADERS, TIMEOUT, URL_WEB_UGC_VIEW
 from .schemes import GetUGCViewResponse
-
-
-HEADERS = {
-    'origin': 'https://www.bilibili.com',
-    'referer': 'https://www.bilibili.com/',
-    'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
-                  'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
-    'accept': 'application/json, text/plain, */*',
-    'Sec-Ch-Ua': '"Chromium";v="124", "Google Chrome";v="124", "Not-A.Brand";v="99"',
-    'Sec-Ch-Ua-Mobile': '?0',
-    'Sec-Ch-Ua-Platform': '"macOS"',
-    'Sec-Fetch-Dest': 'empty',
-    'Sec-Fetch-Mode': 'cors',
-    'Sec-Fetch-Site': 'same-site'
-}
-TIMEOUT = 5
-
-
-URL_WEB_UGC_VIEW = 'https://api.bilibili.com/x/web-interface/view'
 
 
 async def get_ugc_view(
@@ -62,7 +44,8 @@ async def get_ugc_view_response(
         async with session.get(
             URL_WEB_UGC_VIEW,
             params=params,
-            headers=HEADERS
+            headers=HEADERS,
+            timeout=aiohttp.ClientTimeout(total=float(TIMEOUT))
         ) as response:
             content = await response.read()
             data = json.loads(content.decode('utf-8'))

--- a/tests/unittest/core/test_factory.py
+++ b/tests/unittest/core/test_factory.py
@@ -1,40 +1,116 @@
+from http import HTTPStatus
+from unittest.mock import patch
+
+from aiohttp import InvalidUrlClientError
+from multidict import CIMultiDict, CIMultiDictProxy
 import pytest
 
 from bili_jeans.core.factory import parse_web_view_url
+from tests.utils import get_mock_async_response
 
 
-def test_parse_web_view_url_with_bvid_based_ugc_view():
+HTML_CONTENT = b'<!DOCTYPE html><html lang="zh-Hans"></html>'
+
+
+@patch('aiohttp.ClientSession.get')
+async def test_parse_web_view_url_with_bvid_based_ugc_view(mock_get_req):
     sample_url = (
         'https://www.bilibili.com/video/BV1tN4y1F79k?'
         'vd_source=eab9f46166d54e0b07ace25e908097ae&'
         'spm_id_from=333.788.videopod.sections'
     )
-    actual_metadata = parse_web_view_url(sample_url)
+    mock_get_req.return_value.__aenter__.return_value = get_mock_async_response(
+        HTTPStatus.OK.value,
+        HTML_CONTENT,
+        CIMultiDictProxy(
+            CIMultiDict(
+                location=(
+                    '/video/BV1tN4y1F79k?'
+                    'vd_source=eab9f46166d54e0b07ace25e908097ae&'
+                    'spm_id_from=333.788.videopod.sections'
+                )
+            )
+        )
+    )
+    actual_metadata = await parse_web_view_url(sample_url)
 
     assert actual_metadata.aid is None
     assert actual_metadata.bvid == 'BV1tN4y1F79k'
 
 
-def test_parse_web_view_url_with_aid_based_ugc_view():
+@patch('aiohttp.ClientSession.get')
+async def test_parse_web_view_url_with_aid_based_ugc_view(mock_get_req):
     sample_url = (
         'https://www.bilibili.com/video/av2271112/?'
         'vd_source=eab9f46166d54e0b07ace25e908097ae'
     )
-    actual_metadata = parse_web_view_url(sample_url)
+    mock_get_req.return_value.__aenter__.return_value = get_mock_async_response(
+        HTTPStatus.OK.value,
+        HTML_CONTENT,
+        CIMultiDictProxy(CIMultiDict())
+    )
+    actual_metadata = await parse_web_view_url(sample_url)
 
     assert actual_metadata.aid == 2271112
     assert actual_metadata.bvid is None
 
 
-def test_parse_web_view_url_with_non_url_params():
+@patch('aiohttp.ClientSession.get')
+async def test_parse_web_view_url_with_non_url_params(mock_get_req):
     params = 'mock_string'
-    with pytest.raises(ValueError, match='Invalid Url: mock_string'):
-        parse_web_view_url(params)
+    mock_get_req.side_effect = InvalidUrlClientError(params)
+    with pytest.raises(
+        ValueError,
+        match=f'Invalid Url. source Url: {params}, destination Url: {params}'
+    ):
+        await parse_web_view_url(params)
 
 
-def test_parse_web_view_url_with_invalid_url_but_contains_path():
+@patch('aiohttp.ClientSession.get')
+async def test_parse_web_view_url_with_invalid_url_but_contains_path(mock_get_req):
     params = '/video/BV1tN4y1F79k'
-    actual_metadata = parse_web_view_url(params)
+    mock_get_req.side_effect = InvalidUrlClientError(params)
+    actual_metadata = await parse_web_view_url(params)
 
     assert actual_metadata.aid is None
     assert actual_metadata.bvid == 'BV1tN4y1F79k'
+
+
+@patch('aiohttp.ClientSession.get')
+async def test_parse_web_view_url_of_pgc_resource_with_bvid(mock_get_req):
+    """
+    PGC resource also has bvid-declared Url
+    the metadata should be based on destination Url
+    """
+    sample_url = 'https://www.bilibili.com/video/BV1tL4y1i7UZ/'
+    dest_url = 'https://www.bilibili.com/bangumi/play/ep249470'
+    mock_get_req.return_value.__aenter__.return_value = get_mock_async_response(
+        HTTPStatus.OK.value,
+        HTML_CONTENT,
+        CIMultiDictProxy(CIMultiDict(location=dest_url))
+    )
+    with pytest.raises(
+        ValueError,
+        match=f'Invalid Url. source Url: {sample_url}, destination Url: {dest_url}'
+    ):
+        await parse_web_view_url(sample_url)
+
+
+@patch('aiohttp.ClientSession.get')
+async def test_parse_web_view_url_of_pgc_resource_with_aid(mock_get_req):
+    """
+    PGC resource also has aid-declared Url
+    the metadata should be based on destination Url
+    """
+    sample_url = 'https://www.bilibili.com/video/av31703892/'
+    dest_url = 'https://www.bilibili.com/bangumi/play/ep249469'
+    mock_get_req.return_value.__aenter__.return_value = get_mock_async_response(
+        HTTPStatus.OK.value,
+        HTML_CONTENT,
+        CIMultiDictProxy(CIMultiDict(location=dest_url))
+    )
+    with pytest.raises(
+        ValueError,
+        match=f'Invalid Url. source Url: {sample_url}, destination Url: {dest_url}'
+    ):
+        await parse_web_view_url(sample_url)

--- a/tests/unittest/core/test_factory.py
+++ b/tests/unittest/core/test_factory.py
@@ -1,0 +1,40 @@
+import pytest
+
+from bili_jeans.core.factory import parse_web_view_url
+
+
+def test_parse_web_view_url_with_bvid_based_ugc_view():
+    sample_url = (
+        'https://www.bilibili.com/video/BV1tN4y1F79k?'
+        'vd_source=eab9f46166d54e0b07ace25e908097ae&'
+        'spm_id_from=333.788.videopod.sections'
+    )
+    actual_metadata = parse_web_view_url(sample_url)
+
+    assert actual_metadata.aid is None
+    assert actual_metadata.bvid == 'BV1tN4y1F79k'
+
+
+def test_parse_web_view_url_with_aid_based_ugc_view():
+    sample_url = (
+        'https://www.bilibili.com/video/av2271112/?'
+        'vd_source=eab9f46166d54e0b07ace25e908097ae'
+    )
+    actual_metadata = parse_web_view_url(sample_url)
+
+    assert actual_metadata.aid == 2271112
+    assert actual_metadata.bvid is None
+
+
+def test_parse_web_view_url_with_non_url_params():
+    params = 'mock_string'
+    with pytest.raises(ValueError, match='Invalid Url: mock_string'):
+        parse_web_view_url(params)
+
+
+def test_parse_web_view_url_with_invalid_url_but_contains_path():
+    params = '/video/BV1tN4y1F79k'
+    actual_metadata = parse_web_view_url(params)
+
+    assert actual_metadata.aid is None
+    assert actual_metadata.bvid == 'BV1tN4y1F79k'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,16 +1,23 @@
 """
 Utilities for unit test and functional test
 """
-from typing import cast
+from typing import cast, Optional
 
 from aiohttp.client import _RequestContextManager
+from multidict import CIMultiDictProxy
 
 
 class MockAsyncResponse(object):
 
-    def __init__(self, status_code: int, content: bytes) -> None:
+    def __init__(
+        self,
+        status_code: int,
+        content: bytes,
+        headers: Optional[CIMultiDictProxy] = None
+    ) -> None:
         self._status_code = status_code
         self._content = content
+        self._headers = headers
 
     async def read(self) -> bytes:
         return self._content
@@ -21,13 +28,18 @@ class MockAsyncResponse(object):
     async def __aenter__(self) -> 'MockAsyncResponse':
         return self
 
+    @property
+    def headers(self) -> Optional[CIMultiDictProxy]:
+        return self._headers
+
 
 def get_mock_async_response(
     status_code: int,
-    content: bytes
+    content: bytes,
+    headers: Optional[CIMultiDictProxy] = None
 ) -> _RequestContextManager:
     mock_resp = cast(
         _RequestContextManager,
-        MockAsyncResponse(status_code, content)
+        MockAsyncResponse(status_code, content, headers)
     )
     return mock_resp


### PR DESCRIPTION
# Description

Parse out metadata according to Web view Url

- support **UGC** resources, which is with '/video', declared by BV ID or AV ID
- could figure out other resources (e.g. PGC) declared as `/video`

# Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Unit test which mocks the HTTP request
- call the method locally

# Additional Notes

N/A
