### PR TITLE
feat: download danmaku

### DIFF
--- a/bili_jeans/core/constants.py
+++ b/bili_jeans/core/constants.py
@@ -30,6 +30,7 @@ TIMEOUT = 5
 ################
 URL_WEB_UGC_PLAY = 'https://api.bilibili.com/x/player/wbi/playurl'
 URL_WEB_UGC_VIEW = 'https://api.bilibili.com/x/web-interface/view'
+URL_WEB_DANMAKU = 'https://api.bilibili.com/x/v1/dm/list.so'
 
 
 class QualityItem(NamedTuple):
@@ -202,3 +203,4 @@ CHUNK_SIZE: int = int(1024 * 1024)
 
 
 MIME_TYPE_VIDEO_MP4 = 'video/mp4'
+MIME_TYPE_XML = 'text/xml'


### PR DESCRIPTION
# Description

download Danmaku as XML file if necessary, controlled by parameters `enable_danmaku`

# Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Unit test which mocks the HTTP request
- call the method locally

# Additional Notes

N/A
