### PR TITLE
fix: hardcode file extension instead of mime type based

### DIFF
--- a/bili_jeans/core/constants.py
+++ b/bili_jeans/core/constants.py
@@ -203,7 +203,9 @@ class BitRateId(QualityId):
 CHUNK_SIZE: int = int(1024 * 1024)
 
 
-MIME_TYPE_JPEG = 'image/jpeg'
-MIME_TYPE_JSON = 'application/json'
-MIME_TYPE_VIDEO_MP4 = 'video/mp4'
-MIME_TYPE_XML = 'text/xml'
+FILE_EXT_JPG = '.jpg'
+FILE_EXT_JSON = '.json'
+FILE_EXT_M4A = '.m4a'
+FILE_EXT_MP4 = '.mp4'
+FILE_EXT_SRT = '.srt'
+FILE_EXT_XML = '.xml'

--- a/bili_jeans/core/download/ugc_audio.py
+++ b/bili_jeans/core/download/ugc_audio.py
@@ -2,15 +2,14 @@
 create download task for audio of UGC page
 """
 import logging
-from mimetypes import guess_extension
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from .download_task import (
     BaseCoroutineDownloadTask,
     StreamDownloadTask
 )
-from ..constants import BitRateId
+from ..constants import BitRateId, FILE_EXT_M4A
 from ..utils import filter_avail_quality_id
 from ..schemes import GetUGCPlayResponse, PageData
 from ..schemes.ugc_play import DashMediaItem, GetUGCPlayDataDash
@@ -36,7 +35,7 @@ def create_audio_task(
         return None
 
     if ugc_play.data.dash is not None:
-        url, mime_type = _get_audio_from_dash(
+        url = _get_audio_from_dash(
             ugc_play.data.dash,
             bit_rate_id,
             reverse_bit_rate
@@ -47,7 +46,7 @@ def create_audio_task(
         )
         return None
 
-    filename = f'{page_data.bvid}/{page_data.cid}{guess_extension(mime_type) or ""}'
+    filename = f'{page_data.bvid}/{page_data.cid}{FILE_EXT_M4A}'
     file_p = dir_path.joinpath(filename)
 
     download_task = StreamDownloadTask(
@@ -61,7 +60,7 @@ def _get_audio_from_dash(
     dash: GetUGCPlayDataDash,
     bit_rate_id: Optional[int] = None,
     reverse_bit_rate: bool = False
-) -> Tuple[str, str]:
+) -> str:
     audios: List[DashMediaItem] = []
     if dash.audio is not None:
         audios.extend(dash.audio)
@@ -82,4 +81,4 @@ def _get_audio_from_dash(
     audios = [audio for audio in audios if audio.id_field == bit_rate_id]
     audio, *_ = audios
 
-    return audio.base_url, audio.mime_type
+    return audio.base_url

--- a/bili_jeans/core/download/ugc_cover.py
+++ b/bili_jeans/core/download/ugc_cover.py
@@ -1,7 +1,6 @@
 """
 create download task for cover of UGC page
 """
-from mimetypes import guess_extension
 from pathlib import Path
 from typing import Optional
 
@@ -9,7 +8,7 @@ from .download_task import (
     BaseCoroutineDownloadTask,
     StreamDownloadTask
 )
-from ..constants import MIME_TYPE_JPEG
+from ..constants import FILE_EXT_JPG
 from ..schemes import PageData
 
 
@@ -18,9 +17,8 @@ def create_cover_task(
     dir_path: Path
 ) -> Optional[BaseCoroutineDownloadTask]:
     url = page_data.cover
-    mime_type = MIME_TYPE_JPEG
 
-    filename = f'{page_data.bvid}/{page_data.cid}{guess_extension(mime_type) or ""}'
+    filename = f'{page_data.bvid}/{page_data.cid}{FILE_EXT_JPG}'
     file_p = dir_path.joinpath(filename)
 
     download_task = StreamDownloadTask(

--- a/bili_jeans/core/download/ugc_danmaku.py
+++ b/bili_jeans/core/download/ugc_danmaku.py
@@ -1,7 +1,6 @@
 """
 create download task for danmaku of UGC page
 """
-from mimetypes import guess_extension
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlencode, urlparse
@@ -11,7 +10,7 @@ from .download_task import (
     StreamDownloadTask
 )
 from ..constants import (
-    MIME_TYPE_XML,
+    FILE_EXT_XML,
     URL_WEB_DANMAKU
 )
 from ..schemes import PageData
@@ -24,9 +23,8 @@ def create_danmaku_task(
     url = urlparse(URL_WEB_DANMAKU)._replace(
         query=urlencode({'oid': page_data.cid})
     ).geturl()
-    mime_type = MIME_TYPE_XML
 
-    filename = f'{page_data.bvid}/{page_data.cid}{guess_extension(mime_type) or ""}'
+    filename = f'{page_data.bvid}/{page_data.cid}{FILE_EXT_XML}'
     file_p = dir_path.joinpath(filename)
 
     download_task = StreamDownloadTask(

--- a/bili_jeans/core/download/ugc_subtitle.py
+++ b/bili_jeans/core/download/ugc_subtitle.py
@@ -2,7 +2,6 @@
 create download task for subtitle of UGC page
 """
 import logging
-from mimetypes import guess_extension
 from pathlib import Path
 from typing import List, Optional
 
@@ -11,7 +10,7 @@ from .download_task import (
     StreamDownloadTask,
     SRTSubtitleDownloadTask
 )
-from ..constants import MIME_TYPE_JSON
+from ..constants import FILE_EXT_JSON, FILE_EXT_SRT
 from ..schemes import GetUGCPlayerResponse, PageData
 
 
@@ -36,16 +35,15 @@ def create_subtitle_tasks(
 
     for subtitle in ugc_player.data.subtitle.subtitles:
         url = 'https:' + subtitle.subtitle_url
-        mime_type = MIME_TYPE_JSON
         filename_wo_ext = f'{page_data.bvid}/{page_data.cid}.{subtitle.id_field}'
 
-        raw_filename = f'{filename_wo_ext}{guess_extension(mime_type) or ""}'
+        raw_filename = f'{filename_wo_ext}{FILE_EXT_JSON}'
         raw_file_p = dir_path.joinpath(raw_filename)
         download_raw_task = StreamDownloadTask(
             url=url,
             file=str(raw_file_p)
         )
-        srt_filename = f'{filename_wo_ext}.srt'
+        srt_filename = f'{filename_wo_ext}{FILE_EXT_SRT}'
         srt_file_p = dir_path.joinpath(srt_filename)
         download_srt_task = SRTSubtitleDownloadTask(
             url=url,


### PR DESCRIPTION
# Description

declare file extension by constants, instead of guessing by mime type since the behavior would be different from various platforms

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Unit test which mocks the HTTP request

# Additional Notes

N/A
